### PR TITLE
unsafeURI throws a helpful error

### DIFF
--- a/src/Web/Atom.hs
+++ b/src/Web/Atom.hs
@@ -132,7 +132,9 @@ makeEntry uri title updated = Entry
 -- function is partial so only use this if you're hardcoding the URI string and
 -- you're sure that it's valid./
 unsafeURI :: String -> URI
-unsafeURI = fromJust . parseURI
+unsafeURI s = case parseURI s of
+                Just u -> u
+                Nothing -> error $ "Unable to parse URI string: " ++ s
 
 -- -------------------------
 -- External XML construction


### PR DESCRIPTION
Instead of "fromJust: Nothing" (which could be from anywhere!), the error explains that the library was unable to parse the URI and shows the URI string.